### PR TITLE
chore: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ out/
 *.njsproj
 *.sln
 *.sw?
+
+# === Environment ===
+.env


### PR DESCRIPTION
Add .env to .gitignore to prevent environment files from being tracked.