### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,5 +1,8 @@
 name: Backend CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/yokozi-jp/spring-modulith-ai-harness/security/code-scanning/1](https://github.com/yokozi-jp/spring-modulith-ai-harness/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/backend-ci.yml`, directly under `name:` (or under `on:`), so it applies to all jobs unless overridden.  
For this pipeline, the minimal required permission is:

- `contents: read` (needed for `actions/checkout` and general repository read access)

No other write scopes are required by the shown steps (`setup-java`, `setup-gradle`, Gradle runs, and `upload-artifact` do not require repo write permissions). This preserves existing functionality while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
