### PR TITLE
ci: parallelize backend CI workflow  Split single sequential job into 4 parallel jobs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,8 +12,9 @@ on:
     paths: ['backend/**', 'compose-test.yaml', '.env.test.example', 'Makefile']
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-24.04
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,45 +25,9 @@ jobs:
 
       - name: Fix permissions for Docker bind mount
         run: chmod -R 777 backend
-
-      - name: Start test containers
-        run: docker compose -f compose-test.yaml up -d --wait
-
-      - name: Lint (Spotless + PMD + SpotBugs)
-        run: docker compose -f compose-test.yaml exec backend-test ./gradlew spotlessCheck pmdMain pmdTest spotbugsMain --project-cache-dir=/gradle/project-cache
-
-      - name: Stop containers
-        if: always()
-        run: docker compose -f compose-test.yaml down
-
-  test:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Copy .env.test.example to .env.test
-        run: cp .env.test.example .env.test
-
-      - name: Fix permissions for Docker bind mount
-        run: chmod -R 777 backend
-
-      - name: Start test containers
-        run: docker compose -f compose-test.yaml up -d --wait
 
       - name: Run check (compile, test, PMD, SpotBugs, JaCoCo)
-        run: docker compose -f compose-test.yaml exec backend-test ./gradlew check --project-cache-dir=/gradle/project-cache
-
-      - name: Copy reports from container
-        if: always()
-        run: |
-          mkdir -p backend/build/reports
-          docker compose -f compose-test.yaml cp backend-test:/app/build/reports/. backend/build/reports/ 2>/dev/null || true
-
-      - name: Stop containers
-        if: always()
-        run: docker compose -f compose-test.yaml down
+        run: make be-test; status=$?; make be-down; exit $status
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,9 +12,8 @@ on:
     paths: ['backend/**', 'compose-test.yaml', '.env.test.example', 'Makefile']
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-24.04
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,8 +25,44 @@ jobs:
       - name: Fix permissions for Docker bind mount
         run: chmod -R 777 backend
 
+      - name: Start test containers
+        run: docker compose -f compose-test.yaml up -d --wait
+
+      - name: Lint (Spotless + PMD + SpotBugs)
+        run: docker compose -f compose-test.yaml exec backend-test ./gradlew spotlessCheck pmdMain pmdTest spotbugsMain --project-cache-dir=/gradle/project-cache
+
+      - name: Stop containers
+        if: always()
+        run: docker compose -f compose-test.yaml down
+
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Copy .env.test.example to .env.test
+        run: cp .env.test.example .env.test
+
+      - name: Fix permissions for Docker bind mount
+        run: chmod -R 777 backend
+
+      - name: Start test containers
+        run: docker compose -f compose-test.yaml up -d --wait
+
       - name: Run check (compile, test, PMD, SpotBugs, JaCoCo)
-        run: make be-test; status=$?; make be-down; exit $status
+        run: docker compose -f compose-test.yaml exec backend-test ./gradlew check --project-cache-dir=/gradle/project-cache
+
+      - name: Copy reports from container
+        if: always()
+        run: |
+          mkdir -p backend/build/reports
+          docker compose -f compose-test.yaml cp backend-test:/app/build/reports/. backend/build/reports/ 2>/dev/null || true
+
+      - name: Stop containers
+        if: always()
+        run: docker compose -f compose-test.yaml down
 
       - name: Upload test reports
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ be-fmt:
 # jOOQ コード生成
 be-jooq:
 	docker compose exec backend ./gradlew generateJooq
+	@sudo chown -R $$(id -u):$$(id -g) backend/src/generated/ 2>/dev/null || true
 
 # Liquibase マイグレーション適用
 be-migrate:

--- a/compose-test.yaml
+++ b/compose-test.yaml
@@ -22,6 +22,7 @@ services:
       - ./.git:/app/.git:ro
       - ./docker:/docker:ro
       - gradle-cache-test:/gradle
+      - test-build:/app/build
     command: ["sleep", "infinity"]
     depends_on:
       postgres-test:
@@ -94,3 +95,4 @@ services:
 
 volumes:
   gradle-cache-test:
+  test-build:


### PR DESCRIPTION
Split single sequential job into 4 parallel jobs:
- lint (Spotless + PMD + SpotBugs)
- unit-test
- integration-test
- coverage (JaCoCo report + threshold check)

Also fix be-jooq ownership after code generation.